### PR TITLE
Add link capacity framework

### DIFF
--- a/Assets/Orbits/SP_basic_0031.cs
+++ b/Assets/Orbits/SP_basic_0031.cs
@@ -1175,11 +1175,6 @@ public class SP_basic_0031 : MonoBehaviour
 		SatelliteSP0031 sat = null, prevsat;
 		int id = -1;
 
-		// ClearRoute();
-		// reset_route = true;
-
-		// TODO: might remove reset_route entirely.
-
 		/* pathnum indicates the order the appearance. This is strictly ascending. So any route that has a pathnum cannot be
 		equal or lower than that of the previously generated path. */
 		if (pathnum <= lastpath)
@@ -1199,54 +1194,20 @@ public class SP_basic_0031 : MonoBehaviour
 
 		int uplinks = 0, downlinks = 0; // what are uplinks and downlinks?
 
-		// rg.ResetEndpointNodes(city1, city2);
-
-		// ResetRoute(city1, city2);
-		// sat0pos = satlist[0].gameobject.transform.position;
-		// BuildRouteGraph(rg, city1, city2, maxdist, margin); // Only builds a route graph when a route reset has been requested.
-
 		/* Build another route graph if a route reset has been requested. */
-		// reset_route = true;
+		ResetRoute(city1, city2);
+
 		if (reset_route)
 		{
 			float satmoveddist = Vector3.Distance(satlist[0].gameobject.transform.position, sat0pos);
 
-			// this here, sets something that hasn't been set in the other one.
 			if (route_init == false || satmoveddist * km_per_unit > margin || graph_on)
 			{
-				// This happens only once. it happens when the route hasn't been initalized yet.
-				/* Either, a route hasn't been initialised, the satellites have moved beyond the functional boundary, or the graph has just been turned on (?) */
-				ResetRoute(city1, city2);
+				// WHAT IS THE SAT0POS VARIABLE?			
 				sat0pos = satlist[0].gameobject.transform.position;
-				BuildRouteGraph(rg, city1, city2, maxdist, margin); // Only builds a route graph when a route reset has been requested.
-				route_init = true;
-			}
-			else
-			{
-				/* reset dijkstra, but not neighbours */
-				// TODO: temprorarily turn this off
-
-				// Reset dijsktra. Also resets the positions of the nodes.
-				// rg.ResetEndpointNodes(city1, city2);
-				// ResetRoutePos(city1, city2); // maybe this is missing?
-				ResetRoute(city1, city2);
-				// sat0pos = satlist[0].gameobject.transform.position;
-				BuildRouteGraph(rg, city1, city2, maxdist, margin);
-
 			}
 		}
-		else
-		{
-			ResetRoute(city1, city2);
-			// sat0pos = satlist[0].gameobject.transform.position;
-			BuildRouteGraph(rg, city1, city2, maxdist, margin);
-			/* resets distances assigned to all nodes with dijkstra */
-			// ResetRoutePos(city1, city2);
-			// UpdateRouteGraphEndpoints(rg, city1, city2, maxdist, margin);
-			// rg.ResetNodeDistances(); // and then this is most likely a big problem as well.
-			// Unsure what this is. Shouldn't be enabled anyways. since reset_route is always true
-			// rg.ResetEndpointNodes(city1, city2);
-		}
+		BuildRouteGraph(rg, city1, city2, maxdist, margin);
 
 		/* N.B. 
 		* rg = RouteGraph

--- a/Assets/RouteGraph.cs
+++ b/Assets/RouteGraph.cs
@@ -88,6 +88,25 @@ public class RouteGraph
 		return null;
 	}
 
+	// public Link GetLink(int satid1, int satid2)
+	// {
+	// 	// TODO: is this actually of any use.
+	// 	Node node1 = this.GetNode(satid1);
+	// 	Node node2 = this.GetNode(satid2);
+
+	// 	for (int index = 0; index < _links.length; index += 1)
+	// 	{
+	// 		// this is kind of a rudimentary way of doing so. Probably, what'd be better is to have some sort of hash table.
+	// 		if (_links[index].OtherNode(this).Id == id)
+	// 		{
+	// 			return _links[index];
+	// 		}
+	// 	}
+	// 	return None; // If there aren't any nodes.
+	// }
+
+
+
 	// only call AddEndNodes after you've added all the satellites
 	public void AddEndNodes()
 	{
@@ -144,6 +163,7 @@ public class RouteGraph
 
 	public void ResetOnPathStatus()
 	{
+		// TODO: am I still using this?
 		for (int i = 0; i < nodecount; i++)
 		{
 			nodes[i].OnPath = false;

--- a/Assets/Routing.cs
+++ b/Assets/Routing.cs
@@ -10,11 +10,6 @@ public class Link
 	float dist; // length of link
 	bool dist_limited;  // RF links have a distance limit, lasers do not
 
-	// TODO: change the maximum packet capacity of the link. Make it variable
-	uint max_capacity = 10; // Maximum packet capacity of the link. 
-
-	uint curr_load = 0; // Current packet load on the link.
-
 	public Link(Node n1, Node n2, bool dist_limited_)
 	{
 		nodes = new Node[2];
@@ -64,27 +59,6 @@ public class Link
 		}
 	}
 
-	public void resetLoad()
-	{
-		this.curr_load = 0;
-	}
-
-	/* Add a load of <packet_count> packets to the link.
-	If <curr_load> exceeds the <max_capacity>, no packets more packets can be sent over this link. */
-	public void increaseLoad(uint packet_count)
-	{
-		if (this.IsFlooded())
-		{
-			this.curr_load += packet_count;
-		}
-	}
-
-	/* Check if the number of incoming packets exceeds the link capacity.
-	If <curr_load> exceeds the <max_capacity>, no packets more packets can be sent over this link. */
-	public bool IsFlooded()
-	{
-		return (this.curr_load > this.max_capacity);
-	}
 }
 
 public class Node

--- a/Assets/Routing.cs
+++ b/Assets/Routing.cs
@@ -8,13 +8,20 @@ public class Link
 	Node[] nodes;
 	float dist; // length of link
 	bool dist_limited;  // RF links have a distance limit, lasers do not
-	public Link(Node n1, Node n2, bool dist_limited_)
+
+	// TODO: change the maximum packet capacity of the link. Make it variable
+	uint max_capacity = 10; // Maximum packet capacity of the link. 
+
+	uint curr_load = 0; // Current packet load on the link.
+
+	public Link(Node n1, Node n2, bool dist_limited_, uint max_capacity)
 	{
 		nodes = new Node[2];
 		nodes[0] = n1;
 		nodes[1] = n2;
 		dist = Vector3.Distance(n1._position, n2._position);
 		dist_limited = dist_limited_;
+		this.max_capacity = max_capacity;
 	}
 
 	public Link(Node n1, Node n2, float dist_, bool dist_limited_)
@@ -55,6 +62,28 @@ public class Link
 		{
 			dist = Node.INFINITY; // unreachable
 		}
+	}
+
+	public void resetLoad()
+	{
+		this.curr_load = 0;
+	}
+
+	/* Add a load of <packet_count> packets to the link.
+	If <curr_load> exceeds the <max_capacity>, no packets more packets can be sent over this link. */
+	public void increaseLoad(uint packet_count)
+	{
+		if (this.IsFlooded())
+		{
+			this.curr_load += packet_count;
+		}
+	}
+
+	/* Check if the number of incoming packets exceeds the link capacity.
+	If <curr_load> exceeds the <max_capacity>, no packets more packets can be sent over this link. */
+	public bool IsFlooded()
+	{
+		return (this.curr_load > this.max_capacity);
 	}
 }
 

--- a/Assets/Routing.cs
+++ b/Assets/Routing.cs
@@ -1,5 +1,6 @@
 ﻿using UnityEngine;
 using System.Collections;
+using System.Collections.Generic;
 
 
 
@@ -14,14 +15,13 @@ public class Link
 
 	uint curr_load = 0; // Current packet load on the link.
 
-	public Link(Node n1, Node n2, bool dist_limited_, uint max_capacity)
+	public Link(Node n1, Node n2, bool dist_limited_)
 	{
 		nodes = new Node[2];
 		nodes[0] = n1;
 		nodes[1] = n2;
 		dist = Vector3.Distance(n1._position, n2._position);
 		dist_limited = dist_limited_;
-		this.max_capacity = max_capacity;
 	}
 
 	public Link(Node n1, Node n2, float dist_, bool dist_limited_)
@@ -98,10 +98,12 @@ public class Node
 	public int _orbit = -5; // TODO: make this private. Was it always public?
 	float _dist = INFINITY; // distance from src.
 	Node _parent_node;  // predecessor on path from src
-						//bool _done = false;
+
+	private Dictionary<int, Link> _neighbours = new Dictionary<int, Link>(); // all node neighbours and their respective links.
+
 	public int QueuePosition;
 
-	bool _on_path = false; /* Determines if the node is on the selected path. */
+	bool _on_path = false; /* Determines if the node is on the selected path. */ // TODO: is this even used?
 
 	public Node(int id, Vector3 pos)
 	{
@@ -238,6 +240,7 @@ public class Node
 		Link l = new Link(this, node, dist_limited);
 		AddLink(l);
 		node.AddLink(l);
+		// _neighbours.Add(node.Id, l);
 	}
 
 	public void AddNeighbour(Node node, float dist, bool dist_limited)
@@ -257,12 +260,27 @@ public class Node
 		Link l = new Link(this, node, dist, dist_limited); /* create a link object with the distance data. */
 		AddLink(l); /* add the link to our node */
 		node.AddLink(l); /* add the link to the desired neighbour */
+		// _neighbours.Add(node.Id, l);
 	}
 
 	public Node GetNeighbour(Link l)
 	{
 		Node n = l.OtherNode(this);
 		return n;
+	}
+
+	public Link GetLinkByNeighbour(int id)
+	{
+		// return _neighbours[satid];
+		for (int i = 0; i < _linkcount; i++)
+		{
+			if (_links[i].OtherNode(this).Id == id)
+			{
+				// this is the correct neighbour
+				return _links[i];
+			}
+		}
+		return null;
 	}
 
 	public Link GetLink(int index)


### PR DESCRIPTION
Completes: #7 

Adds a `MAX_CAPACITY` constant that determines the maximum Mbit load that a link can handle. Every time a path sends packets along a route, the amount of Mbits on that link is increased. If the link load capacity is reached, any ensuing links are not processed, and that particular link becomes flooded.

Note that the links in this model are assumed to be **full duplex**, i.e., that packets going in one direction on a link do not share the same physical link as packets going in the opposite direction on said theoretical link.